### PR TITLE
Fix mojibake in RAG results and city filter

### DIFF
--- a/backend/tenantfirstaid/langchain_tools.py
+++ b/backend/tenantfirstaid/langchain_tools.py
@@ -2,14 +2,23 @@
 This module defines Tools for an Agent to call
 """
 
+import logging
 from typing import Callable, Optional, Type, cast
 
+import httpx
+from google.api_core import exceptions as google_exceptions
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
 from langchain_core.tools import BaseTool, tool
 from langchain_google_community import VertexAISearchRetriever
 from langgraph.config import get_stream_writer
 from pydantic import BaseModel, Field
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from .constants import (
     LETTER_TEMPLATE,
@@ -18,6 +27,43 @@ from .constants import (
 )
 from .google_auth import load_gcp_credentials
 from .location import OregonCity, UsaState
+
+logger = logging.getLogger(__name__)
+
+
+def _repair_mojibake(text: str) -> str:
+    """Attempt to repair UTF-8 text that was incorrectly decoded as Latin-1.
+
+    Vertex AI may return corpus text with mojibake (e.g. â€™ instead of ')
+    if the source document's UTF-8 encoding was misread as Latin-1 at index
+    time. This reverses that by re-encoding as Latin-1 and decoding as UTF-8.
+
+    Logs a warning if the repair itself appears to corrupt the text (i.e. the
+    round-trip fails or introduces replacement characters).
+    """
+    try:
+        repaired = text.encode("latin-1").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError) as e:
+        # Round-trip failure means the text has non-ASCII characters that are
+        # not the result of UTF-8-as-Latin-1 mojibake (e.g. bare § U+00A7 from
+        # a dropped 0xC2 byte). Correct behaviour — leave the text alone.
+        char = (
+            repr(text[e.start]) if hasattr(e, "start") and e.start < len(text) else "?"
+        )
+        logger.debug(
+            "mojibake repair skipped — round-trip failed at pos %s (char %s): %.120r",
+            getattr(e, "start", "?"),
+            char,
+            text,
+        )
+        return text
+
+    if repaired != text:
+        logger.debug(
+            "mojibake repair applied to RAG passage (first 120 chars): %.120r", text
+        )
+
+    return repaired
 
 
 class RagBuilder:
@@ -60,21 +106,34 @@ class RagBuilder:
             filter=filter,
         )
 
+    @retry(
+        retry=retry_if_exception_type(
+            (httpx.ReadError, google_exceptions.ServiceUnavailable)
+        ),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=0.5, max=4),
+        reraise=True,
+        before_sleep=lambda rs: logger.warning(
+            "RAG search retry #%d after %s", rs.attempt_number, rs.outcome.exception()
+        ),
+    )
     def search(self, query: str) -> str:
         docs = self.rag.invoke(
             input=query,
         )
 
-        return "\n".join([doc.page_content for doc in docs])
+        return "\n".join([_repair_mojibake(doc.page_content) for doc in docs])
 
 
 def _filter_builder(state: UsaState, city: Optional[OregonCity] = None) -> str:
     if city is None:
-        city_or_null = "null"
+        city_filter = 'city: ANY("null")'
     else:
-        city_or_null = city.lower()
+        # Include both city-specific and state-level ("null") documents so the
+        # agent sees both layers of law in a single retrieval.
+        city_filter = f'city: ANY("{city.lower()}", "null")'
 
-    return f"""city: ANY("{city_or_null}") AND state: ANY("{state.lower()}")"""
+    return f"""{city_filter} AND state: ANY("{state.lower()}")"""
 
 
 @tool
@@ -135,7 +194,18 @@ class CityStateLawsInputSchema(BaseModel):
                        Rephrase the user's question using relevant legal terms and
                        ORS references when applicable (e.g. 'week-to-week tenancy
                        nonpayment notice timing ORS 90.394'). Avoid paraphrasing so
-                       broadly that specific statutory details are lost."""
+                       broadly that specific statutory details are lost.
+
+                       Frame queries around the legal relationship and direction of
+                       obligation: who is required, entitled, or prohibited to do what
+                       (e.g. 'landlord required to pay interest on security deposit'
+                       rather than 'landlord security deposit interest'). On retry
+                       after a miss, change the framing angle — try the other party's
+                       perspective or restate as an obligation/entitlement — rather
+                       than repeating the same terms with an ORS number appended.
+                       Always include the specific action being contested in the query
+                       (e.g. 'landlord required to pay interest' not just 'landlord
+                       obligation security deposit')."""
     )
     state: UsaState
     city: Optional[OregonCity] = None
@@ -148,6 +218,26 @@ class CityStateLawsInputSchema(BaseModel):
                        Use a larger value (6–8) when the question spans multiple
                        statutes, involves city overrides, or an initial retrieval
                        missed the relevant passage.""",
+    )
+    max_extractive_answer_count: int = Field(
+        default=1,
+        ge=1,
+        le=5,
+        description="""Extractive answers per document (1–5). Each is a short
+                       passage the search engine identifies as directly relevant.
+                       Increase on retry if the first search returned passages
+                       from the right document but missed the specific subsection
+                       you need.""",
+    )
+    max_extractive_segment_count: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="""Extractive segments per document (1–10). Segments are
+                       longer surrounding blocks of text that provide more context
+                       than answers. Increase on retry when the answer likely sits
+                       adjacent to what was returned (e.g. the right ORS section
+                       was found but a neighboring subsection was missed).""",
     )
 
 

--- a/backend/tests/test_langchain_tools.py
+++ b/backend/tests/test_langchain_tools.py
@@ -6,17 +6,22 @@ import json
 from typing import Dict, cast
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from google.oauth2 import service_account
 from google.oauth2.credentials import Credentials
+from hypothesis import given
+from hypothesis import strategies as st
 from langchain_core.tools import StructuredTool
 
 from tenantfirstaid.constants import DatastoreKey
 from tenantfirstaid.google_auth import load_gcp_credentials
 from tenantfirstaid.langchain_tools import (
     CityStateLawsInputSchema,
+    RagBuilder,
     _filter_builder,
     _make_rag_tool,
+    _repair_mojibake,
     generate_letter,
     get_active_rag_tools,
     get_letter_template,
@@ -200,6 +205,49 @@ def test_retrieve_city_state_laws_returns_joined_docs(mock_rag_class):
     assert "Doc2 content" in result
 
 
+# --- _repair_mojibake property tests ---
+
+
+@pytest.mark.property
+@given(st.text(alphabet=st.characters(max_codepoint=0x7F)))
+def test_repair_mojibake_ascii_unchanged(text: str) -> None:
+    """Pure ASCII text is returned unchanged — no mojibake to repair."""
+    assert _repair_mojibake(text) == text
+
+
+@pytest.mark.property
+@given(st.text(alphabet=st.characters(blacklist_categories=("Cs",))))
+def test_repair_mojibake_repairs_genuine_mojibake(original: str) -> None:
+    """Genuine mojibake (UTF-8 bytes misread as Latin-1) is fully repaired.
+
+    Simulates the Vertex AI encoding defect: the original string's UTF-8
+    bytes are misread as Latin-1, producing mojibake. The repair should
+    recover the original string exactly.
+
+    Surrogates (category Cs, U+D800–U+DFFF) are excluded because they cannot
+    be encoded as UTF-8, so the test setup would raise UnicodeEncodeError
+    before reaching the function under test.
+    """
+    mojibake = original.encode("utf-8").decode("latin-1")
+    assert _repair_mojibake(mojibake) == original
+
+
+@pytest.mark.property
+@given(
+    st.text(alphabet=st.characters(min_codepoint=0x80, max_codepoint=0xBF), min_size=1)
+)
+def test_repair_mojibake_continuation_byte_chars_unchanged(text: str) -> None:
+    """Text with chars in U+0080–U+00BF is returned unchanged.
+
+    These chars (including § U+00A7) encode to Latin-1 bytes 0x80–0xBF,
+    which are UTF-8 continuation bytes. They can never form valid UTF-8
+    without a preceding start byte, so the round-trip fails and the
+    original text is returned as-is. This covers the Vertex AI defect
+    where the leading 0xC2 byte of a UTF-8 § sequence is dropped.
+    """
+    assert _repair_mojibake(text) == text
+
+
 @patch("tenantfirstaid.langchain_tools.RagBuilder")
 def test_retrieve_city_state_laws_empty_results(mock_rag_class):
     """Test behavior when RAG returns no documents."""
@@ -268,7 +316,12 @@ def test_make_rag_tool_custom_filter_builder(mock_rag_class):
         _func(query="test query", state=UsaState("or"))
 
     custom_filter.assert_called_once_with(
-        query="test query", state=UsaState("or"), city=None, max_documents=5
+        query="test query",
+        state=UsaState("or"),
+        city=None,
+        max_documents=5,
+        max_extractive_answer_count=1,
+        max_extractive_segment_count=3,
     )
     mock_rag_class.assert_called_once_with(
         data_store_id="fake-id",
@@ -286,9 +339,9 @@ def test_filter_builder_state_only():
 
 
 def test_filter_builder_with_city():
-    """Test filter with city and state."""
+    """Test filter with city includes state-level docs."""
     result = _filter_builder(UsaState("or"), OregonCity("eugene"))
-    assert 'city: ANY("eugene")' in result
+    assert 'city: ANY("eugene", "null")' in result
     assert 'state: ANY("or")' in result
 
 
@@ -302,3 +355,49 @@ def test_generate_letter_empty_string(mock_get_stream_writer):
     result = _func(letter="")
     mock_writer.assert_called_once_with({"type": "letter", "content": ""})
     assert result == "Letter generated successfully."
+
+
+# --- RagBuilder.search retry tests ---
+
+
+@patch("tenantfirstaid.langchain_tools.load_gcp_credentials")
+@patch("tenantfirstaid.langchain_tools.VertexAISearchRetriever")
+def test_rag_search_retries_on_httpx_read_error(mock_retriever_class, mock_creds):
+    """Transient httpx.ReadError is retried and succeeds on second attempt."""
+    mock_creds.return_value = MagicMock()
+    mock_doc = MagicMock()
+    mock_doc.page_content = "result text"
+
+    mock_instance = mock_retriever_class.return_value
+    mock_instance.invoke.side_effect = [
+        httpx.ReadError("Connection reset by peer"),
+        [mock_doc],
+    ]
+
+    builder = RagBuilder(
+        data_store_id="fake-datastore-id",
+        filter='city: ANY("null") AND state: ANY("or")',
+    )
+    result = builder.search("test query")
+
+    assert result == "result text"
+    assert mock_instance.invoke.call_count == 2
+
+
+@patch("tenantfirstaid.langchain_tools.load_gcp_credentials")
+@patch("tenantfirstaid.langchain_tools.VertexAISearchRetriever")
+def test_rag_search_gives_up_after_three_attempts(mock_retriever_class, mock_creds):
+    """After 3 failed attempts the error is reraised."""
+    mock_creds.return_value = MagicMock()
+
+    mock_instance = mock_retriever_class.return_value
+    mock_instance.invoke.side_effect = httpx.ReadError("Connection reset by peer")
+
+    builder = RagBuilder(
+        data_store_id="fake-datastore-id",
+        filter='city: ANY("null") AND state: ANY("or")',
+    )
+    with pytest.raises(httpx.ReadError):
+        builder.search("test query")
+
+    assert mock_instance.invoke.call_count == 3

--- a/backend/tests/test_langsmith_dataset.py
+++ b/backend/tests/test_langsmith_dataset.py
@@ -1084,25 +1084,33 @@ def test_cmd_dataset_diff_mixed(tmp_path, capsys):
 # JSON-serializable values: booleans must come before integers in st.one_of
 # because bool is a subclass of int and Hypothesis would otherwise generate
 # True/False as integers.
+#
+# Surrogate characters (Unicode category Cs, U+D800–U+DFFF) are excluded from
+# all text strategies: json.dumps raises UnicodeEncodeError for lone surrogates,
+# so they would abort the test before reaching the assertion.
+_json_text = st.text(alphabet=st.characters(blacklist_categories=("Cs",)))
 _json_primitive = st.one_of(
     st.none(),
     st.booleans(),
     st.integers(),
     st.floats(allow_nan=False, allow_infinity=False),
-    st.text(),
+    _json_text,
 )
 _json_value = st.recursive(
     _json_primitive,
     lambda children: st.one_of(
         st.lists(children),
-        st.dictionaries(st.text(), children),
+        st.dictionaries(_json_text, children),
     ),
     max_leaves=10,
 )
+# Use a direct dict strategy rather than filtering _json_value, which would
+# reject most generated values (primitives/lists) and trigger filter_too_much.
+_json_dict = st.dictionaries(_json_text, _json_value)
 
 
 @pytest.mark.property
-@given(records=st.lists(_json_value.filter(lambda v: isinstance(v, dict)), max_size=20))
+@given(records=st.lists(_json_dict, max_size=20))
 @settings(max_examples=200)
 def test_read_jsonl_roundtrip(records):
     """Any list of dicts written as JSONL should parse back to the same list."""
@@ -1131,7 +1139,7 @@ def test_extract_rubric_roundtrip(before, rubric, after):
 
 
 @pytest.mark.property
-@given(st.text())
+@given(st.text(alphabet=st.characters(blacklist_categories=("Cs",))))
 def test_local_or_remote_classification(value):
     """Strings ending in .jsonl always return Path; all others return str."""
     result = local_or_remote(value)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Three bug fixes in the RAG retrieval pipeline:

**Mojibake repair** — Vertex AI returns corpus text where UTF-8 was misread as Latin-1 at index time (e.g. `â€™` instead of `'`). `_repair_mojibake` reverses this by re-encoding as Latin-1 and decoding as UTF-8. Falls back gracefully when the round-trip fails (e.g. bare `§` U+00A7 from a dropped `0xC2` byte).

**City filter** — The city filter only included city-specific documents, missing state-level (`null`) docs. When a city is specified, the filter now includes both city docs and state-level docs in a single retrieval pass.

**Extraction schema params** — Added `max_extractive_answer_count` and `max_extractive_segment_count` to `CityStateLawsInputSchema` so the LLM can tune extraction depth on retry when the right document was found but the specific subsection was missed.

Also adds retry logic on `httpx.ReadError` / `ServiceUnavailable` in `RagBuilder.search`, and fixes the property test strategy to exclude Unicode surrogates (which can't be encoded as UTF-8).

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

```bash
cd backend
VERTEX_AI_DATASTORE_LAWS=fake uv run pytest tests/test_langchain_tools.py tests/test_langsmith_dataset.py -m langchain -v
```

## Added/updated tests?

- [x] Yes

## Documentation

- [ ] If this PR changes the system architecture, `Architecture.md` has been updated

## [optional] Are there any post deployment tasks we need to perform?